### PR TITLE
Problems with Nino34 workflow

### DIFF
--- a/cwsl/vt_modules/vt_nino34.py
+++ b/cwsl/vt_modules/vt_nino34.py
@@ -65,7 +65,7 @@ class IndicesNino34(vistrails_module.Module):
         self.out_pattern = PatternGenerator('user', 'default').pattern
         
         # Set up the output command for this module, adding extra options.
-        self.positional_args = [('year_start', 2), ('year_end', 3)]
+        self.positional_args = [('startdate_info', 2), ('enddate_info', 3)]
         
     def compute(self):
 
@@ -96,8 +96,8 @@ class IndicesNino34(vistrails_module.Module):
 
         try:
             this_process.execute(simulate=configuration.simulate_execution)
-        except Exception, e:
-            raise vistrails_module.ModuleError(self, e.output)
+        except Exception as e:
+            raise vistrails_module.ModuleError(self, repr(e))
 
         process_output = this_process.file_creator
 

--- a/cwsl/vt_modules/vt_xmltonc.py
+++ b/cwsl/vt_modules/vt_xmltonc.py
@@ -70,8 +70,8 @@ class XmlToNc(vistrails_module.Module):
         
         # Set up the output command for this module, adding extra options.
         self.positional_args = [('variable', 0), ('--force', -1, 'raw')]
-        self.keyword_args = {'start_year': 'year_start',
-                             'end_year': 'year_end'}
+        self.keyword_args = {'start_year': 'startdate_info',
+                             'end_year': 'enddate_info'}
                                 
     def compute(self):
 
@@ -86,7 +86,7 @@ class XmlToNc(vistrails_module.Module):
 
         cons_for_output = new_cons
 
-        # Execute the seas_vars process.
+        # Execute the xml_to_nc process.
         this_process = ProcessUnit([in_dataset],
                                    self.out_pattern,
                                    self.command,
@@ -97,8 +97,8 @@ class XmlToNc(vistrails_module.Module):
 
         try:
             this_process.execute(simulate=configuration.simulate_execution)
-        except Exception, e:
-            raise vistrails_module.ModuleError(self, e.output)
+        except Exception as e:
+            raise vistrails_module.ModuleError(self, repr(e))
 
         process_output = this_process.file_creator
 


### PR DESCRIPTION
I found the problem - one was that the try/except block in the vt_modules used the old-style
    `except Exception, e:`
instead of the 2.6+:
    `except Exception as a:`
The block in the vt module existed to pass errors through to the gui, but it relies on the exceptions having a `e.output` attribute, which a `KeyError` doesn't have.

The reason that the workflow was throwing a `KeyError`, was that the `xml_to_nc` and  `nino_34` scripts need keyword arguments built from the `DataSet` constraints - I updated the keyword arguments to use the renamed `Constraints` (`startdate_info` etc).


